### PR TITLE
Add readHDOP and getAccuracy

### DIFF
--- a/firmware/AssetTracker.cpp
+++ b/firmware/AssetTracker.cpp
@@ -41,6 +41,15 @@ float AssetTracker::readLonDeg(){
     return gps.longitudeDegrees;
 }
 
+float AssetTracker::readHDOP(){
+    return gps.HDOP;
+}
+
+float AssetTracker::getAccuracy(){
+  // 1.8 taken from specs at https://learn.adafruit.com/adafruit-ultimate-gps/
+  return 1.8 * readHDOP();
+}
+
 String AssetTracker::readLatLon(){
     String latLon = String::format("%f,%f",gps.latitudeDegrees,gps.longitudeDegrees);
     return latLon;

--- a/firmware/AssetTracker.cpp
+++ b/firmware/AssetTracker.cpp
@@ -45,7 +45,7 @@ float AssetTracker::readHDOP(){
     return gps.HDOP;
 }
 
-float AssetTracker::getAccuracy(){
+float AssetTracker::getGpsAccuracy(){
   // 1.8 taken from specs at https://learn.adafruit.com/adafruit-ultimate-gps/
   return 1.8 * readHDOP();
 }

--- a/firmware/AssetTracker.h
+++ b/firmware/AssetTracker.h
@@ -24,7 +24,10 @@ class AssetTracker {
     readLat(void),
     readLon(void),
     readLatDeg(void),
-    readLonDeg(void);
+    readLonDeg(void),
+    readHDOP(void),
+    getAccuracy(void);
+
   bool
     gpsFix(void);
   char

--- a/firmware/AssetTracker.h
+++ b/firmware/AssetTracker.h
@@ -26,7 +26,7 @@ class AssetTracker {
     readLatDeg(void),
     readLonDeg(void),
     readHDOP(void),
-    getAccuracy(void);
+    getGpsAccuracy(void);
 
   bool
     gpsFix(void);


### PR DESCRIPTION
Added a solution to issue #15

Added two functions to get information about the current accuracy of the GPS.
Needed for example to do a Kalman filter of the signal or any other
signal processing.

The calculation of the accuracy is not done in any spectacular way,
just a multiplication of the positional accuracy, but it should at least give
a sense of what the accuracy is.